### PR TITLE
Revert "xCalc 7.0.1 - Simplified Button Hover"

### DIFF
--- a/x/calc/index.html
+++ b/x/calc/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>xCalc v7.0.1</title>
+		<title>xCalc v7.0.0</title>
 		<link rel='stylesheet' type='text/css' href='style.css'>
 		<script type="text/javascript" src="math.js"></script>
 	</head>
@@ -9,7 +9,7 @@
 		<iframe name="dummyframe" id="dummyframe" style="display: none;"></iframe>
 		<div class="header"><a href="http://gamergeeked.us">home</a></div>
 		<div class="calculator" id="calculator">
-			<div class="title"><b>xCalc v7.0.1</b><br><span id="dyn"></div><!--
+			<div class="title"><b>xCalc v7.0.0</b><br><span id="dyn"></div><!--
 
 					OUTPUT OPTIONS
 				Operations

--- a/x/calc/style.css
+++ b/x/calc/style.css
@@ -10,7 +10,7 @@
 	background-color: white;
 	color: #005f3b;
 	border: solid;
-	border-width: 0px;
+	border-width: 5px;
 } .function {
 	background-color: #5f003b;
 	border: none;
@@ -21,7 +21,7 @@
 	background-color: white;
 	color: #5f003b;
 	border: solid;
-	border-width: 0px;
+	border-width: 5px;
 } .constant {
 	background-color: #003b5f;
 	border: none;
@@ -33,7 +33,7 @@
 	background-color: white;
 	color: #003b5f;
 	border: solid;
-	border-width: 0px;
+	border-width: 5px;
 } .setter {
 	background-color: black;
 	border: none;
@@ -45,7 +45,7 @@
 	background-color: white;
 	color: black;
 	border: solid;
-	border-width: 0px;
+	border-width: 5px;
 } .largeButton {
 	font-size: 32px;
 	height: 100px;
@@ -155,5 +155,5 @@
 	background-color: #ffffff;
 	color: black;
 	border:  2px solid #003b5f;
-	border-width: 0px;
+	border-width: 5px;
 }


### PR DESCRIPTION
- Removed outlines from hovered buttons. While this is a feature loss, it may result in a cleaner look (opinions will vary) and should fix rendering issues on Safari