### PR TITLE
xCalc 7.3.5 - No Blank Strings

### DIFF
--- a/x/calc/index.html
+++ b/x/calc/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>xCalc v7.3.4</title>
+		<title>xCalc v7.3.5</title>
 		<link rel='stylesheet' type='text/css' href='style.css'>
 		<script type="text/javascript" src="math.js"></script>
 	</head>
@@ -9,7 +9,7 @@
 		<iframe name="dummyframe" id="dummyframe" style="display: none;"></iframe>
 		<div class="header"><a href="http://gamergeeked.us">home</a></div>
 		<div class="calculator" id="calculator">
-			<div class="title"><b>xCalc v7.3.4</b><br><span id="dyn"></div><!--
+			<div class="title"><b>xCalc v7.3.5</b><br><span id="dyn"></div><!--
 
 					OUTPUT OPTIONS
 				Operations

--- a/x/calc/script.js
+++ b/x/calc/script.js
@@ -13,10 +13,10 @@ const digitSet = [
 var a_input = 0;
 var ans = 0;
 var Num = {
-	a: 0,
-	b: 0,
-	x: 0,
-	y: 0,
+	a: 2,
+	b: 2,
+	x: 2,
+	y: 2,
 	set: function(key = 'a', value = ans) {
 		value = math.complex(value);
 		if (math.re(math.im(value)) == 0) {
@@ -239,7 +239,7 @@ function Input(value = Field.get()) {
 			Dyn.alert("Debug Mode disabled.");
 		}
 		return;
-	}
+	} else if (value == "") {return}
 	try {
 		Num.set(Request.num, value);
 		if (Request.op) {


### PR DESCRIPTION
- Variables default to 2, similar to in previous versions of xCalc
- Nothing will happen if you try to enter a blank string